### PR TITLE
fix: clang narrowing warnings

### DIFF
--- a/include/private/dsp/arch/aarch64/asimd/pmath/log.h
+++ b/include/private/dsp/arch/aarch64/asimd/pmath/log.h
@@ -45,19 +45,19 @@ namespace lsp
 
             static const float LOGB_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(2.0f * M_LOG2E),
-                LSP_DSP_VEC4(2.0f * M_LOG2E)
+                LSP_DSP_VEC4(2.0f * (float)M_LOG2E),
+                LSP_DSP_VEC4(2.0f * (float)M_LOG2E)
             };
 
             static const float LOGE_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(1.0f / M_LOG2E),
-                LSP_DSP_VEC4(1.0f / M_LOG2E)
+                LSP_DSP_VEC4(1.0f / (float)M_LOG2E),
+                LSP_DSP_VEC4(1.0f / (float)M_LOG2E)
             };
 
             static const float LOGD_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(2.0f * M_LOG10E),
+                LSP_DSP_VEC4(2.0f * (float)M_LOG10E),
                 LSP_DSP_VEC4(0.301029995663981f) // 1/log2(10)
             };
         )

--- a/include/private/dsp/arch/arm/neon-d32/pmath/log.h
+++ b/include/private/dsp/arch/arm/neon-d32/pmath/log.h
@@ -45,19 +45,19 @@ namespace lsp
 
             static const float LOGB_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(2.0f * M_LOG2E),
-                LSP_DSP_VEC4(2.0f * M_LOG2E)
+                LSP_DSP_VEC4(2.0f * (float)M_LOG2E),
+                LSP_DSP_VEC4(2.0f * (float)M_LOG2E)
             };
 
             static const float LOGE_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(1.0f / M_LOG2E),
-                LSP_DSP_VEC4(1.0f / M_LOG2E)
+                LSP_DSP_VEC4(1.0f / (float)M_LOG2E),
+                LSP_DSP_VEC4(1.0f / (float)M_LOG2E)
             };
 
             static const float LOGD_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(2.0f * M_LOG10E),
+                LSP_DSP_VEC4(2.0f * (float)M_LOG10E),
                 LSP_DSP_VEC4(0.301029995663981f) // 1/log2(10)
             };
         )

--- a/include/private/dsp/arch/generic/pmath/log.h
+++ b/include/private/dsp/arch/generic/pmath/log.h
@@ -33,13 +33,13 @@ namespace lsp
         void logb1(float *dst, size_t count)
         {
             for (size_t i=0; i<count; ++i)
-                dst[i] = ::logf(dst[i]) * (float)M_LOG2E;
+                dst[i] = ::logf(dst[i]) * M_LOG2E;
         }
 
         void logb2(float *dst, const float *src, size_t count)
         {
             for (size_t i=0; i<count; ++i)
-                dst[i] = ::logf(src[i]) * (float)M_LOG2E;
+                dst[i] = ::logf(src[i]) * M_LOG2E;
         }
 
         void loge1(float *dst, size_t count)

--- a/include/private/dsp/arch/generic/pmath/log.h
+++ b/include/private/dsp/arch/generic/pmath/log.h
@@ -33,13 +33,13 @@ namespace lsp
         void logb1(float *dst, size_t count)
         {
             for (size_t i=0; i<count; ++i)
-                dst[i] = ::logf(dst[i]) * M_LOG2E;
+                dst[i] = ::logf(dst[i]) * (float)M_LOG2E;
         }
 
         void logb2(float *dst, const float *src, size_t count)
         {
             for (size_t i=0; i<count; ++i)
-                dst[i] = ::logf(src[i]) * M_LOG2E;
+                dst[i] = ::logf(src[i]) * (float)M_LOG2E;
         }
 
         void loge1(float *dst, size_t count)

--- a/include/private/dsp/arch/x86/avx2/pmath/log.h
+++ b/include/private/dsp/arch/x86/avx2/pmath/log.h
@@ -46,17 +46,17 @@ namespace lsp
 
             static const float LOGB_C[] __lsp_aligned32 =
             {
-                LSP_DSP_VEC8(2.0f * M_LOG2E)
+                LSP_DSP_VEC8(2.0f * (float)M_LOG2E)
             };
 
             static const float LOGE_C[] __lsp_aligned32 =
             {
-                LSP_DSP_VEC8(1.0f / M_LOG2E)
+                LSP_DSP_VEC8(1.0f / (float)M_LOG2E)
             };
 
             static const float LOGD_C[] __lsp_aligned32 =
             {
-                LSP_DSP_VEC8(2.0f * M_LOG10E),
+                LSP_DSP_VEC8(2.0f * (float)M_LOG10E),
                 LSP_DSP_VEC8(0.301029995663981f) // 1/log2(10)
             };
         )

--- a/include/private/dsp/arch/x86/avx512/pmath/log.h
+++ b/include/private/dsp/arch/x86/avx512/pmath/log.h
@@ -46,17 +46,17 @@ namespace lsp
 
             static const float LOGB_C[] __lsp_aligned64 =
             {
-                LSP_DSP_VEC16(2.0f * M_LOG2E)
+                LSP_DSP_VEC16(2.0f * (float)M_LOG2E)
             };
 
             static const float LOGE_C[] __lsp_aligned64 =
             {
-                LSP_DSP_VEC16(1.0f / M_LOG2E)
+                LSP_DSP_VEC16(1.0f / (float)M_LOG2E)
             };
 
             static const float LOGD_C[] __lsp_aligned64 =
             {
-                LSP_DSP_VEC16(2.0f * M_LOG10E),
+                LSP_DSP_VEC16(2.0f * (float)M_LOG10E),
                 LSP_DSP_VEC16(0.301029995663981f) // 1/log2(10)
             };
         )

--- a/include/private/dsp/arch/x86/sse2/pmath/log.h
+++ b/include/private/dsp/arch/x86/sse2/pmath/log.h
@@ -46,17 +46,17 @@ namespace lsp
 
             static const float LOGB_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(2.0f * M_LOG2E)
+                LSP_DSP_VEC4(2.0f * (float)M_LOG2E)
             };
 
             static const float LOGE_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(1.0f / M_LOG2E)
+                LSP_DSP_VEC4(1.0f / (float)M_LOG2E)
             };
 
             static const float LOGD_C[] __lsp_aligned16 =
             {
-                LSP_DSP_VEC4(2.0f * M_LOG10E),
+                LSP_DSP_VEC4(2.0f * (float)M_LOG10E),
                 LSP_DSP_VEC4(0.301029995663981f) // 1/log2(10)
             };
         )


### PR DESCRIPTION
On my Gentoo machine that uses Clang as the default C/C++ compiler, I'm getting build errors concerning the narrowing of double to float when emerging `media-libs/lsp-plugins`. This PR should fix them trivially.

I only tested on my amd64 machine, so hopefully the extrapolated fixes to the files of the other architectures should still be fine.